### PR TITLE
Fix ClassNotFoundException in Caffeine for native image

### DIFF
--- a/commons/src/main/java/org/hyades/common/CaffeineReflectionConfiguration.java
+++ b/commons/src/main/java/org/hyades/common/CaffeineReflectionConfiguration.java
@@ -1,0 +1,17 @@
+package org.hyades.common;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Register classes of Caffeine cache for reflection.
+ * <p>
+ * Fixes {@link ClassNotFoundException} when running as native image.
+ *
+ * @see <a href="https://quarkus.io/guides/cache#going-native">Quarkus Cache docs</a>
+ */
+@SuppressWarnings("unused")
+@RegisterForReflection(classNames = {
+        "com.github.benmanes.caffeine.cache.SSSW"
+})
+public class CaffeineReflectionConfiguration {
+}


### PR DESCRIPTION
Something changed after upgrading Quarkus to 2.16.0.Final, causing Caffeine to use a different cache implementation behind the scenes.

```
ERROR [io.qua.run.Application] (main) Failed to start application (with profile [prod]): java.lang.ClassNotFoundException: com.github.benmanes.caffeine.cache.SSSW
2023-01-25 21:17:26     at java.base@17.0.6/java.lang.Class.forName(DynamicHub.java:1132)
2023-01-25 21:17:26     at java.base@17.0.6/java.lang.Class.forName(DynamicHub.java:1105)
2023-01-25 21:17:26     at com.github.benmanes.caffeine.cache.LocalCacheFactory.loadFactory(LocalCacheFactory.java:84)
2023-01-25 21:17:26     at com.github.benmanes.caffeine.cache.LocalCacheFactory.newBoundedLocalCache(LocalCacheFactory.java:40)
2023-01-25 21:17:26     at com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalAsyncCache.<init>(BoundedLocalCache.java:4216)
2023-01-25 21:17:26     at com.github.benmanes.caffeine.cache.Caffeine.buildAsync(Caffeine.java:1096)
2023-01-25 21:17:26     at io.quarkus.cache.runtime.caffeine.CaffeineCacheImpl.<init>(CaffeineCacheImpl.java:71)
2023-01-25 21:17:26     at io.quarkus.cache.runtime.caffeine.CaffeineCacheManagerBuilder$1.get(CaffeineCacheManagerBuilder.java:56)
2023-01-25 21:17:26     at io.quarkus.cache.runtime.caffeine.CaffeineCacheManagerBuilder$1.get(CaffeineCacheManagerBuilder.java:34)
2023-01-25 21:17:26     at io.quarkus.cache.CacheManager_7ace4235729bbc654ace276b403267860dc707de_Synthetic_Bean.createSynthetic(Unknown Source)
2023-01-25 21:17:26     at io.quarkus.cache.CacheManager_7ace4235729bbc654ace276b403267860dc707de_Synthetic_Bean.create(Unknown Source)
2023-01-25 21:17:26     at io.quarkus.cache.CacheManager_7ace4235729bbc654ace276b403267860dc707de_Synthetic_Bean.create(Unknown Source)
2023-01-25 21:17:26     at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:113)
2023-01-25 21:17:26     at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:37)
2023-01-25 21:17:26     at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:34)
2023-01-25 21:17:26     at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:26)
```

Signed-off-by: nscuro <nscuro@protonmail.com>