### PR TITLE
Build multi-platform images for jar-based distribution

### DIFF
--- a/.github/workflows/publishJar.yml
+++ b/.github/workflows/publishJar.yml
@@ -47,6 +47,7 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/mirror-service:latest
             ghcr.io/${{ github.repository_owner }}/mirror-service:${{ steps.determine-project-version.outputs.PROJECT_VERSION }}
+          platforms: linux/amd64,linux/arm64
       - name: Build and push notification-publisher container image
         uses: docker/build-push-action@v3
         with:
@@ -56,6 +57,7 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/notification-publisher:latest
             ghcr.io/${{ github.repository_owner }}/notification-publisher:${{ steps.determine-project-version.outputs.PROJECT_VERSION }}
+          platforms: linux/amd64,linux/arm64
       - name: Build and push repository-meta-analyzer container image
         uses: docker/build-push-action@v3
         with:
@@ -65,6 +67,7 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/repository-meta-analyzer:latest
             ghcr.io/${{ github.repository_owner }}/repository-meta-analyzer:${{ steps.determine-project-version.outputs.PROJECT_VERSION }}
+          platforms: linux/amd64,linux/arm64
       - name: Build and push vulnerability-analyzer container image
         uses: docker/build-push-action@v3
         with:
@@ -74,3 +77,4 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/vulnerability-analyzer:latest
             ghcr.io/${{ github.repository_owner }}/vulnerability-analyzer:${{ steps.determine-project-version.outputs.PROJECT_VERSION }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
I missed this part when I raised #236. We currently only build these images for `amd64`.

Signed-off-by: nscuro <nscuro@protonmail.com>